### PR TITLE
Remove the requirement of procmacro2_semver_exempt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,3 @@ members = [
     "examples/input",
     "examples/modules"
 ]
-
-[patch.crates-io]
-proc-macro2 = { git = "https://github.com/csharad/proc-macro2", branch = "feature_flagged" }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ struct MyApp;
 impl Render for MyApp {
     fn render(&self) -> Markup<Self> {
         html! {
-            Hello World!
+            "Hello World!"
         }
     }
 }

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -8,8 +8,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = { version = "0.4.19", features = ["procmacro2_semver_exempt"] }
+proc-macro2 = "0.4.19"
 syn = { version = "0.15.1", features = ["full", "extra-traits"] }
 quote = "0.6.8"
 heck = "0.3.0"
-

--- a/codegen/src/html/element.rs
+++ b/codegen/src/html/element.rs
@@ -493,7 +493,7 @@ mod test {
 
     #[test]
     fn should_parse_normal_html_element_with_child() {
-        let _: NormalHtmlElement = syn::parse_str("<div>Hello</div>").unwrap();
+        let _: NormalHtmlElement = syn::parse_str(r#"<div>"Hello"</div>"#).unwrap();
     }
 
     #[test]

--- a/codegen/src/html/mod.rs
+++ b/codegen/src/html/mod.rs
@@ -247,12 +247,12 @@ mod test {
         let _: HtmlRoot = syn::parse_str(
             r#"
             <div>
-                <button>Hello World!</button>
+                <button>"Hello World!"</button>
 
-                <span>How are you?</span>
+                <span>"How are you?"</span>
             </div>
 
-            Nice to meet you.
+            "Nice to meet you."
         "#,
         ).unwrap();
     }
@@ -262,7 +262,7 @@ mod test {
         let _: HtmlRoot = syn::parse_str(
             r#"
             <div>
-                My name is { "Anonymous" }.
+                "My name is "{ "Anonymous" }"."
             </div>
             "#,
         ).unwrap();
@@ -271,7 +271,7 @@ mod test {
     #[test]
     fn should_parse_text() {
         let text: Text =
-            syn::parse_str(r#"This is a text.    What do you think about    it?"#).unwrap();
+            syn::parse_str(r#""This is a text. What do you think about it?""#).unwrap();
 
         assert_eq!(text.content, "This is a text. What do you think about it?");
     }
@@ -280,29 +280,12 @@ mod test {
     fn should_parse_multiline_text() {
         let text: Text = syn::parse_str(
             r#"
-            This is a text.
+                "This is a text. "
 
-            This is new line.
-        "#,
+                "This is new line."
+            "#,
         ).unwrap();
 
         assert_eq!(text.content, "This is a text. This is new line.");
-    }
-
-    #[test]
-    fn should_parse_text_with_literal() {
-        let text: Text = syn::parse_str(
-            r#"
-            "This is a literal"
-
-            b"hello"
-
-            12.122
-
-            32
-        "#,
-        ).unwrap();
-
-        assert_eq!(text.content, r#""This is a literal" b"hello" 12.122 32"#);
     }
 }

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -116,7 +116,7 @@ pub fn component(
 /// ## Text
 /// ```ignore,compile_fail
 /// html! {
-///     This is a sample text.
+///     "This is a sample text."
 /// }
 /// ```
 ///
@@ -170,7 +170,7 @@ pub fn component(
 /// ## Expressions in between
 /// ```ignore,compile_fail
 /// html! {
-///     There are { count } people.
+///     "There are "{ count }" people."
 /// }
 /// ```
 #[proc_macro]

--- a/examples/component/Cargo.toml
+++ b/examples/component/Cargo.toml
@@ -16,6 +16,3 @@ version = "0.3.0"
 features = [
     "Event"
 ]
-
-[patch.crates-io]
-proc-macro2 = { git = "https://github.com/csharad/proc-macro2", branch = "feature_flagged" }

--- a/examples/component/src/lib.rs
+++ b/examples/component/src/lib.rs
@@ -46,7 +46,7 @@ struct Button;
 impl Render for Button {
     fn render(&self) -> Markup<Self> {
         html! {
-            <button @click={Self::click}>Toggle</button>
+            <button @click={Self::click}>"Toggle"</button>
         }
     }
 }

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -10,6 +10,3 @@ crate-type = ["cdylib"]
 [dependencies]
 ruukh = { path = "../../" }
 wasm-bindgen = "0.2.21"
-
-[patch.crates-io]
-proc-macro2 = { git = "https://github.com/csharad/proc-macro2", branch = "feature_flagged" }

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -13,17 +13,17 @@ struct MainApp {
 impl Render for MainApp {
     fn render(&self) -> Markup<Self> {
         html! {
-            The count is: { self.count }.
+            "The count is: "{ self.count }"."
             <button @click={|this: &Self, _ev| {
                 this.set_state(|state| {
                     state.count += 1;
                 });
-            }}>Increment</button>
+            }}>"Increment"</button>
             <button @click={|this: &Self, _ev| {
                 this.set_state(|state| {
                     state.count -= 1;
                 });
-            }}>Decrement</button>
+            }}>"Decrement"</button>
         }
     }
 }

--- a/examples/hello_world/Cargo.toml
+++ b/examples/hello_world/Cargo.toml
@@ -10,6 +10,3 @@ crate-type = ["cdylib"]
 [dependencies]
 ruukh = { path = "../../" }
 wasm-bindgen = "0.2.21"
-
-[patch.crates-io]
-proc-macro2 = { git = "https://github.com/csharad/proc-macro2", branch = "feature_flagged" }

--- a/examples/hello_world/src/lib.rs
+++ b/examples/hello_world/src/lib.rs
@@ -10,7 +10,7 @@ struct MainApp;
 impl Render for MainApp {
     fn render(&self) -> Markup<Self> {
         html! {
-            Hello World!
+            "Hello World!"
         }
     }
 }

--- a/examples/input/Cargo.toml
+++ b/examples/input/Cargo.toml
@@ -18,6 +18,3 @@ features = [
     "EventTarget",
     "HtmlInputElement"
 ]
-
-[patch.crates-io]
-proc-macro2 = { git = "https://github.com/csharad/proc-macro2", branch = "feature_flagged" }

--- a/examples/input/src/lib.rs
+++ b/examples/input/src/lib.rs
@@ -19,7 +19,7 @@ impl Render for MainApp {
                 if !self.input.is_empty() {
                     html! {
                         <div>
-                            Your name is { &self.input }.
+                            "Your name is "{ &self.input }"."
                         </div>
                     }
                 } else {

--- a/examples/modules/Cargo.toml
+++ b/examples/modules/Cargo.toml
@@ -10,6 +10,3 @@ crate-type = ["cdylib"]
 [dependencies]
 ruukh = { path = "../../" }
 wasm-bindgen = "0.2.21"
-
-[patch.crates-io]
-proc-macro2 = { git = "https://github.com/csharad/proc-macro2", branch = "feature_flagged" }

--- a/examples/modules/src/lib.rs
+++ b/examples/modules/src/lib.rs
@@ -13,7 +13,7 @@ struct MyApp;
 impl Render for MyApp {
     fn render(&self) -> Markup<Self> {
         html! {
-            <h1>Lorem Post</h1>
+            <h1>"Lorem Post"</h1>
             <Paragraph></Paragraph>
         }
     }

--- a/examples/modules/src/paragraph/contents.rs
+++ b/examples/modules/src/paragraph/contents.rs
@@ -7,12 +7,12 @@ pub struct Contents;
 impl Render for Contents {
     fn render(&self) -> Markup<Self> {
         html! {
-            Lorem ipsum dolor sit amet. 
-            Lorem ipsum dolor sit amet. 
-            Lorem ipsum dolor sit amet. 
-            Lorem ipsum dolor sit amet. 
-            Lorem ipsum dolor sit amet. 
-            Lorem ipsum dolor sit amet. 
+            "Lorem ipsum dolor sit amet." 
+            "Lorem ipsum dolor sit amet." 
+            "Lorem ipsum dolor sit amet." 
+            "Lorem ipsum dolor sit amet." 
+            "Lorem ipsum dolor sit amet." 
+            "Lorem ipsum dolor sit amet." 
         }
     }
 }

--- a/examples/modules/src/paragraph/title.rs
+++ b/examples/modules/src/paragraph/title.rs
@@ -8,7 +8,7 @@ impl Render for Title {
     fn render(&self) -> Markup<Self> {
         html! {
             <h3>
-                Lorem ipsum dolor
+                "Lorem ipsum dolor"
             </h3>
         }
     }

--- a/src/component.rs
+++ b/src/component.rs
@@ -24,10 +24,10 @@
 //!     fn render(&self) -> Markup<Self> {
 //!         html! {
 //!             <div>
-//!                 This is help section
+//!                 "This is help section"
 //!             </div>
 //!             <div>
-//!                 There are a lot of divs here. Here comes a <button>Button</button>
+//!                 "There are a lot of divs here. Here comes a "<button>"Button"</button>
 //!             </div>
 //!         }
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! impl Render for MyApp {
 //!     fn render(&self) -> Markup<Self> {
 //!         html! {
-//!             Hello World!
+//!             "Hello World!"
 //!         }
 //!     }
 //! }

--- a/tests/html.rs
+++ b/tests/html.rs
@@ -6,38 +6,38 @@ use web_sys::Event;
 #[test]
 fn should_expand_single_element() {
     let _: Markup<()> = html! {
-        <div>Hello World!</div>
+        <div>"Hello World!"</div>
     };
 }
 
 #[test]
 fn should_expand_list_of_elements() {
     let _: Markup<()> = html! {
-        <div>Hello</div>
-        <div>World</div>
-        <div>How are you?</div>
+        <div>"Hello"</div>
+        <div>"World"</div>
+        <div>"How are you?"</div>
     };
 }
 
 #[test]
 fn should_expand_text() {
     let _: Markup<()> = html! {
-        Hello World!
+        "Hello World!"
     };
 }
 
 #[test]
 fn should_expand_multiline_text() {
     let _: Markup<()> = html! {
-        Hello World!
-        How are you?
+        "Hello World!"
+        "How are you?"
     };
 }
 
 #[test]
 fn should_expand_element_with_props() {
     let _: Markup<()> = html! {
-        <button disabled={true}>Click</button>
+        <button disabled={true}>"Click"</button>
     };
 }
 
@@ -46,7 +46,7 @@ fn on_click(_: &(), _: Event) {}
 #[test]
 fn should_expand_element_with_event_listener() {
     let _: Markup<()> = html! {
-        <button @click={on_click}>Click</button>
+        <button @click={on_click}>"Click"</button>
     };
 }
 
@@ -58,7 +58,7 @@ fn should_expand_element_with_attributes() {
             @click={on_click}
             @doubleclick={on_click}
             name={"btn"}
-        >Click
+        >"Click"
         </button>
     };
 }


### PR DESCRIPTION
Supporting an API like the following is only possible with `procmacro2_semver_exempt`.
```rust
html! {
  Hello World!
}
```
And passing `RUSTFLAGS='--cfg procmacro2_semver_exempt'` to `cargo build --target wasm32-unknown-unknown` is currently impossible. So, till `Span::start` and `Span::end` stabilize the following syntax will work:

```rust
html! {
  "Hello World!"
}
``` 