### PR TITLE
Standalone component setters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,5 +42,6 @@ members = [
     "examples/counter",
     "examples/component",
     "examples/input",
-    "examples/modules"
+    "examples/modules",
+    "examples/timer"
 ]

--- a/codegen/src/component.rs
+++ b/codegen/src/component.rs
@@ -272,7 +272,7 @@ impl ComponentMeta {
                     #updation_ret_block
                 }
 
-                fn refresh_state(&mut self) {
+                fn refresh_state(&mut self) -> bool {
                     #refresh_state_body
                 }
 
@@ -373,11 +373,17 @@ impl ComponentMeta {
             quote! {
                 let status = self.__status__.0.borrow();
                 let state = status.state_as_ref();
+                let mut changed = false;
                 #(
                     if self.#idents != state.#idents2 {
                         self.#idents3 = state.#idents4.clone();
+
+                        if !changed {
+                            changed = true;
+                        }
                     }
                 )*
+                changed
             }
         }
     }

--- a/codegen/src/component.rs
+++ b/codegen/src/component.rs
@@ -368,7 +368,9 @@ impl ComponentMeta {
         let idents4 = idents;
 
         if self.state_meta.fields.is_empty() {
-            quote!()
+            quote! {
+                false
+            }
         } else {
             quote! {
                 let status = self.__status__.0.borrow();

--- a/codegen/src/suffix.rs
+++ b/codegen/src/suffix.rs
@@ -1,7 +1,9 @@
 /// Prefix to the name of the Props struct of a component.
 pub const PROPS_SUFFIX: &str = "Props";
-/// Prefix to the name of the State struct of a component. 
+/// Prefix to the name of the State struct of a component.
 pub const STATE_SUFFIX: &str = "State";
+/// Prefix to the name of the Status wrapper struct of a component.
+pub const STATUS_SUFFIX: &str = "Status";
 /// Prefix to the name of the Event struct of a component.
 pub const EVENT_SUFFIX: &str = "Event";
 /// Prefix to the name of the Event Props struct of a component.

--- a/examples/timer/Cargo.toml
+++ b/examples/timer/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "timer"
+version = "0.1.0"
+authors = ["Sharad Chand <sharad.d.chand@gmail.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+ruukh = { path = "../../" }
+wasm-bindgen = "0.2.21"
+
+[dependencies.web-sys]
+version = "0.3.0"
+features = [
+    "Window"
+]

--- a/examples/timer/src/lib.rs
+++ b/examples/timer/src/lib.rs
@@ -1,0 +1,47 @@
+#![feature(proc_macro_gen, proc_macro_non_items, decl_macro)]
+
+use ruukh::prelude::*;
+use wasm_bindgen::{prelude::*, JsCast};
+use web_sys::window;
+
+#[component]
+struct MainApp {
+    #[state]
+    seconds: i32,
+}
+
+impl Lifecycle for MainApp {
+    fn created(&self) {
+        // Get a setter to mutate the state within the closure.
+        let setter = self.state_setter();
+
+        let closure = Closure::wrap(Box::new(move || {
+            setter.set_state(|state| {
+                state.seconds += 1;
+            });
+        }) as Box<Fn()>);
+
+        window()
+            .unwrap()
+            .set_interval_with_callback_and_timeout_and_arguments_0(
+                closure.as_ref().unchecked_ref(),
+                1000,
+            ).unwrap();
+
+        // Forget the closure so that it lives for the lifetime of the program.
+        closure.forget();
+    }
+}
+
+impl Render for MainApp {
+    fn render(&self) -> Markup<Self> {
+        html! {
+            "Timer: " { self.seconds }
+        }
+    }
+}
+
+#[wasm_bindgen]
+pub fn run() {
+    App::<MainApp>::new().mount("app");
+}

--- a/src/component.rs
+++ b/src/component.rs
@@ -132,6 +132,12 @@ pub trait Component: 'static {
 
     /// Get the status of the component.
     fn status(&self) -> Option<&Shared<Status<Self::State>>>;
+}
+
+/// Trait to allow mutatation of a component state.
+pub trait SetState {
+    /// State of a component.
+    type State;
 
     /// Mutates the state of the component by executing the closure which
     /// accepts the current state.
@@ -161,10 +167,32 @@ pub trait Component: 'static {
     ///
     /// ## Internals
     ///
-    /// It mutates the state in the `status` field and checks whether it
-    /// differs from the state fields of the component. If they are different
-    /// it then marks the state as dirty.
+    /// When `set_state` is called on a component type, then it checks if any
+    /// changes have happened and only then notifies the app.
+    ///
+    /// When `set_state` is called on a state setter, then it does not do
+    /// any checks and these checks are delegated to `Component::refresh_state`
+    /// implementation.
     fn set_state(&self, mutator: impl FnMut(&mut Self::State));
+}
+
+/// Trait to get a component setter to be used within `'static` closures.
+///
+/// ```ignore
+/// let setter = self.state_setter();
+///
+/// let closure = Box::new(move || {
+///     setter.set_state(|state| {
+///         state.count += 1;
+///     });
+/// });
+/// ```
+pub trait StateSetter {
+    /// Type of setter.
+    type Setter: SetState;
+
+    /// Get a setter on a component.
+    fn state_setter(&self) -> Self::Setter;
 }
 
 /// Stores the state of the component along with the flags to identify whether
@@ -292,13 +320,6 @@ impl Component for RootParent {
     }
 
     fn status(&self) -> Option<&Shared<Status<Self::State>>> {
-        unreachable!(
-            "It is a void component to be used as a render context for a root \
-             component. Not to be used as a component itself."
-        )
-    }
-
-    fn set_state(&self, _: impl FnMut(&mut Self::State)) {
         unreachable!(
             "It is a void component to be used as a render context for a root \
              component. Not to be used as a component itself."

--- a/src/component.rs
+++ b/src/component.rs
@@ -127,8 +127,9 @@ pub trait Component: 'static {
     /// in comparing closures.
     fn update(&mut self, props: Self::Props, events: Self::Events) -> Option<Self::Props>;
 
-    /// Updates the state fields if the status is mutated.
-    fn refresh_state(&mut self);
+    /// Updates the state fields if the status is mutated and returns if
+    /// actually any changes occured.
+    fn refresh_state(&mut self) -> bool;
 
     /// Get the status of the component.
     fn status(&self) -> Option<&Shared<Status<Self::State>>>;
@@ -312,7 +313,7 @@ impl Component for RootParent {
         )
     }
 
-    fn refresh_state(&mut self) {
+    fn refresh_state(&mut self) -> bool {
         unreachable!(
             "It is a void component to be used as a render context for a root \
              component. Not to be used as a component itself."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub type Markup<RCTX> = vdom::VNode<RCTX>;
 /// Things you'll require to build the next great App. Just glob import the
 /// prelude and start building your app.
 pub mod prelude {
-    pub use crate::component::{Component, Lifecycle, Render};
+    pub use crate::component::{Component, Lifecycle, Render, SetState, StateSetter};
     pub use crate::{App, Markup};
     pub use ruukh_codegen::*;
 }

--- a/src/vdom/vcomponent.rs
+++ b/src/vdom/vcomponent.rs
@@ -167,14 +167,16 @@ where
                 .status()
                 .map(|s| s.borrow().is_state_dirty())
                 .unwrap_or(false);
-            if state_changed {
-                comp.borrow_mut().refresh_state();
+            let state_changed = if state_changed {
                 comp.borrow()
                     .status()
                     .unwrap()
                     .borrow_mut()
                     .set_state_dirty(false);
-            }
+                comp.borrow_mut().refresh_state()
+            } else {
+                false
+            };
 
             let props_changed = comp
                 .borrow()

--- a/src/vdom/vcomponent.rs
+++ b/src/vdom/vcomponent.rs
@@ -354,16 +354,12 @@ pub mod test {
             }
         }
 
-        fn refresh_state(&mut self) {
+        fn refresh_state(&mut self) -> bool {
             unreachable!()
         }
 
         fn status(&self) -> Option<&Shared<Status<Self::State>>> {
             Some(&self.__status)
-        }
-
-        fn set_state(&self, _: impl FnMut(&mut Self::State)) {
-            unreachable!()
         }
     }
 

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -16,15 +16,11 @@ fn should_impl_lifecycle() {
             unimplemented!()
         }
 
-        fn refresh_state(&mut self) {
+        fn refresh_state(&mut self) -> bool {
             unimplemented!()
         }
 
         fn status(&self) -> Option<&Rc<RefCell<Status<Self::State>>>> {
-            unimplemented!()
-        }
-
-        fn set_state(&self, _: impl FnMut(&mut Self::State)) {
             unimplemented!()
         }
     }


### PR DESCRIPTION
Closes #12.

This PR allows the following code to mutate state within closures.
```rust
let setter = self.state_setter();

let closure = Box::new(move || {
  setter.set_state(|state| {
    // mutate the state
  });
});
```