### PR TITLE
Option<T> values on attributes of html element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Till version `0.1.0`, each patch version may be breaking change.
 - 
 
 ### Changed
-- 
+- Allowed `Option<T>` on element attributes.
 
 ### Deprecated
 - 

--- a/examples/component/src/lib.rs
+++ b/examples/component/src/lib.rs
@@ -49,13 +49,18 @@ impl MainApp {
     fn click(&self, event: Event);
 )]
 struct Button {
+    disabled: Option<bool>,
     style: &'static str,
 }
 
 impl Render for Button {
     fn render(&self) -> Markup<Self> {
         html! {
-            <button style={self.style} @click={Self::click}>"Toggle"</button>
+            <button
+                style={self.style}
+                disabled={self.disabled}
+                @click={Self::click}
+            >"Toggle"</button>
         }
     }
 }


### PR DESCRIPTION
Fixes #26.

Introduces an additional `None` variant to `AttributeValue` and implements conversions from `Option` type.