### PR TITLE
Remove trait bounds from struct definitions

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -282,7 +282,7 @@ pub trait Render: Lifecycle + Sized {
 ///
 /// Used to convert a (render) contextual events type to a wrapped one.
 /// i.e. `EventProps<RCTX>` to `Events`.
-pub trait FromEventProps<RCTX: Render>: Sized {
+pub trait FromEventProps<RCTX>: Sized {
     /// A contextual events type.
     type From;
 

--- a/src/vdom/mod.rs
+++ b/src/vdom/mod.rs
@@ -39,7 +39,7 @@ pub enum VNode<RCTX> {
     None
 }
 
-impl<RCTX: Render> VNode<RCTX> {
+impl<RCTX> VNode<RCTX> {
     /// Whether the VNode is of `None` variant. 
     pub fn is_none(&self) -> bool {
         match self {

--- a/src/vdom/mod.rs
+++ b/src/vdom/mod.rs
@@ -26,7 +26,7 @@ pub mod vtext;
 mod conversions;
 
 /// A virtual node in a virtual DOM tree.
-pub enum VNode<RCTX: Render> {
+pub enum VNode<RCTX> {
     /// A text vnode
     Text(VText<RCTX>),
     /// An element vnode

--- a/src/vdom/vcomponent.rs
+++ b/src/vdom/vcomponent.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::JsValue;
 use web_sys::Node;
 
 /// The representation of a component in a Virtual DOM.
-pub struct VComponent<RCTX: Render>(Box<dyn ComponentManager<RenderContext = RCTX>>);
+pub struct VComponent<RCTX>(Box<dyn ComponentManager<RenderContext = RCTX>>);
 
 impl<RCTX: Render> VComponent<RCTX> {
     /// Create a new VComponent.
@@ -31,7 +31,7 @@ impl<RCTX: Render> VComponent<RCTX> {
     }
 }
 
-pub(crate) struct ComponentWrapper<COMP: Render, RCTX: Render>
+pub(crate) struct ComponentWrapper<COMP: Render, RCTX>
 where
     COMP::Events: FromEventProps<RCTX>,
 {

--- a/src/vdom/velement.rs
+++ b/src/vdom/velement.rs
@@ -12,7 +12,7 @@ use wasm_bindgen::{prelude::*, JsCast};
 use web_sys::{window, Element, Event, EventTarget, Node};
 
 /// The representation of an element in virtual DOM.
-pub struct VElement<RCTX: Render> {
+pub struct VElement<RCTX> {
     /// The tag of the element. Eg: h, p, div, ...
     tag: &'static str,
     /// The attributes of the given element
@@ -46,10 +46,10 @@ pub enum AttributeValue {
     None,
 }
 
-struct EventListeners<RCTX: Render>(Vec<Box<dyn EventManager<RenderContext = RCTX>>>);
+struct EventListeners<RCTX>(Vec<Box<dyn EventManager<RenderContext = RCTX>>>);
 
 /// Event listener to be invoked on a DOM event.
-pub struct EventListener<RCTX: Render> {
+pub struct EventListener<RCTX> {
     type_: &'static str,
     listener: Option<Box<dyn Fn(&RCTX, Event)>>,
     dom_listener: Option<Closure<dyn Fn(Event)>>,

--- a/src/vdom/vlist.rs
+++ b/src/vdom/vlist.rs
@@ -18,13 +18,13 @@ use web_sys::Node;
 /// The representation of a list of vnodes in the vtree.
 pub struct VList<RCTX>(IndexMap<Key, VNode<RCTX>, FnvBuildHasher>);
 
-impl<RCTX: Render> From<VList<RCTX>> for VNode<RCTX> {
+impl<RCTX> From<VList<RCTX>> for VNode<RCTX> {
     fn from(list: VList<RCTX>) -> VNode<RCTX> {
         VNode::List(list)
     }
 }
 
-impl<RCTX: Render> From<Vec<VNode<RCTX>>> for VList<RCTX> {
+impl<RCTX> From<Vec<VNode<RCTX>>> for VList<RCTX> {
     fn from(children: Vec<VNode<RCTX>>) -> Self {
         VList(
             children
@@ -36,7 +36,7 @@ impl<RCTX: Render> From<Vec<VNode<RCTX>>> for VList<RCTX> {
     }
 }
 
-impl<RCTX: Render> From<IndexMap<Key, VNode<RCTX>, FnvBuildHasher>> for VList<RCTX> {
+impl<RCTX> From<IndexMap<Key, VNode<RCTX>, FnvBuildHasher>> for VList<RCTX> {
     fn from(map: IndexMap<Key, VNode<RCTX>, FnvBuildHasher>) -> Self {
         VList(map)
     }

--- a/src/vdom/vlist.rs
+++ b/src/vdom/vlist.rs
@@ -16,7 +16,7 @@ use wasm_bindgen::prelude::JsValue;
 use web_sys::Node;
 
 /// The representation of a list of vnodes in the vtree.
-pub struct VList<RCTX: Render>(IndexMap<Key, VNode<RCTX>, FnvBuildHasher>);
+pub struct VList<RCTX>(IndexMap<Key, VNode<RCTX>, FnvBuildHasher>);
 
 impl<RCTX: Render> From<VList<RCTX>> for VNode<RCTX> {
     fn from(list: VList<RCTX>) -> VNode<RCTX> {

--- a/src/vdom/vtext.rs
+++ b/src/vdom/vtext.rs
@@ -71,7 +71,7 @@ impl<RCTX> From<VText<RCTX>> for VNode<RCTX> {
     }
 }
 
-impl<RCTX: Render> Display for VText<RCTX> {
+impl<RCTX> Display for VText<RCTX> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         if self.is_comment {
             write!(f, "<!--{}-->", self.content)

--- a/src/vdom/vtext.rs
+++ b/src/vdom/vtext.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::JsValue;
 use web_sys::{window, Node};
 
 /// The representation of text/comment in virtual dom tree.
-pub struct VText<RCTX: Render> {
+pub struct VText<RCTX> {
     /// The content of a text string
     content: String,
     /// Whether the content is a comment

--- a/src/vdom/vtext.rs
+++ b/src/vdom/vtext.rs
@@ -20,7 +20,7 @@ pub struct VText<RCTX> {
     _phantom: PhantomData<RCTX>,
 }
 
-impl<RCTX: Render> VText<RCTX> {
+impl<RCTX> VText<RCTX> {
     /// Create a textual VText.
     pub fn text(content: impl Into<String>) -> VText<RCTX> {
         VText {
@@ -42,23 +42,7 @@ impl<RCTX: Render> VText<RCTX> {
     }
 }
 
-impl<RCTX: Render> From<VText<RCTX>> for VNode<RCTX> {
-    fn from(text: VText<RCTX>) -> VNode<RCTX> {
-        VNode::Text(text)
-    }
-}
-
-impl<RCTX: Render> Display for VText<RCTX> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        if self.is_comment {
-            write!(f, "<!--{}-->", self.content)
-        } else {
-            write!(f, "{}", self.content)
-        }
-    }
-}
-
-impl<RCTX: Render> VText<RCTX> {
+impl<RCTX> VText<RCTX> {
     fn patch_new(&mut self, parent: &Node, next: Option<&Node>) -> Result<(), JsValue> {
         let node: Node = if self.is_comment {
             window()
@@ -78,6 +62,22 @@ impl<RCTX: Render> VText<RCTX> {
         parent.insert_before(&node, next)?;
         self.node = Some(node);
         Ok(())
+    }
+}
+
+impl<RCTX> From<VText<RCTX>> for VNode<RCTX> {
+    fn from(text: VText<RCTX>) -> VNode<RCTX> {
+        VNode::Text(text)
+    }
+}
+
+impl<RCTX: Render> Display for VText<RCTX> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        if self.is_comment {
+            write!(f, "<!--{}-->", self.content)
+        } else {
+            write!(f, "{}", self.content)
+        }
     }
 }
 


### PR DESCRIPTION
Trait bounds only add value if the usage of the type parameters use the functionality that is abstracted over by the trait. This is usually not the case in struct definitions, which is why we can omit the trait bounds here.

I think the trait bounds could also be removed in some other places like `From` conversions or `impl` Blocks that don' use the functionality provided by the `Render` trait. If you are in for that, I'd change those places as well.